### PR TITLE
feat: add build for platform amd64, arm64

### DIFF
--- a/.github/workflows/radio-container.yml
+++ b/.github/workflows/radio-container.yml
@@ -42,3 +42,5 @@ jobs:
           file: ./packages/radio/docker/discord/Dockerfile
           push: true
           tags: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.SHORT_SHA }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          platforms: linux/amd64, linux/arm64
+          provenance: false


### PR DESCRIPTION
add detail to the GitHub workflow file
- add build support arm64, amd64
- disable provenance