### PR TITLE
Feature/add instance name to global

### DIFF
--- a/packages/radio/medley-schema.json
+++ b/packages/radio/medley-schema.json
@@ -4,7 +4,12 @@
   "description": "Configuration file for Medley",
   "type": "object",
   "properties": {
-    "instanceName": "Radio Name",
+    "instanceName": {
+      "type": "string",
+      "title": "Instance Name",
+      "description": "Name of this radio instance (optional)",
+      "minLength": 0
+    },
     "server": {
       "title": "Server",
       "description": "Web server configuration",

--- a/packages/radio/medley-schema.json
+++ b/packages/radio/medley-schema.json
@@ -4,6 +4,7 @@
   "description": "Configuration file for Medley",
   "type": "object",
   "properties": {
+    "instanceName": "Radio Name",
     "server": {
       "title": "Server",
       "description": "Web server configuration",

--- a/packages/radio/src/config/index.ts
+++ b/packages/radio/src/config/index.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { parse } from 'yaml';
-import { z } from 'zod';
+import {z} from 'zod';
 import { DbConfig } from './db';
 import { StationConfig } from './station';
 import { AutomatonConfig } from './automaton';
@@ -15,6 +15,7 @@ async function parseYAML(s: string) {
 }
 
 const Config = z.object({
+  instanceName: z.string(),
   server: ServerConfig,
   db: DbConfig,
   webrtc: WebRtcConfig.optional(),

--- a/packages/radio/src/config/index.ts
+++ b/packages/radio/src/config/index.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { parse } from 'yaml';
-import {z} from 'zod';
+import { z } from 'zod';
 import { DbConfig } from './db';
 import { StationConfig } from './station';
 import { AutomatonConfig } from './automaton';
@@ -15,7 +15,7 @@ async function parseYAML(s: string) {
 }
 
 const Config = z.object({
-  instanceName: z.string(),
+  instanceName: z.string().optional(),
   server: ServerConfig,
   db: DbConfig,
   webrtc: WebRtcConfig.optional(),

--- a/packages/radio/src/remotes/core/global.ts
+++ b/packages/radio/src/remotes/core/global.ts
@@ -1,3 +1,4 @@
 export interface Global {
   getStations(): string[];
+  getInstanceName(): string;
 }

--- a/packages/radio/src/server/expose/core/global.ts
+++ b/packages/radio/src/server/expose/core/global.ts
@@ -16,4 +16,8 @@ export class ExposedGlobal extends MixinEventEmitterOf<RemoteGlobal>() implement
   getStations(): string[] {
     return Array.from(this.#medley.stations.keys());
   }
+
+  getInstanceName(): string {
+    return this.#medley.instanceName
+  }
 }

--- a/packages/radio/src/server/medley-server.ts
+++ b/packages/radio/src/server/medley-server.ts
@@ -23,7 +23,7 @@ import { MedleyAutomaton } from "../discord/automaton";
 import { AutomatonConfig } from "../config/automaton";
 import { StreamingConfig } from "../config/streaming";
 import { StreamingAdapter } from "../streaming/types";
-import { ShoutAdapter } from "../streaming/shout/adapter";
+import { ShoutAdapter } from "../streaming";
 import { IcyAdapter } from "../streaming";
 import { UserModel } from '../db/models/user';
 import { retryable } from "@seamless-medley/utils";

--- a/packages/radio/src/server/medley-server.ts
+++ b/packages/radio/src/server/medley-server.ts
@@ -23,7 +23,7 @@ import { MedleyAutomaton } from "../discord/automaton";
 import { AutomatonConfig } from "../config/automaton";
 import { StreamingConfig } from "../config/streaming";
 import { StreamingAdapter } from "../streaming/types";
-import { ShoutAdapter } from "../streaming/shout/adapter";
+import { ShoutAdapter } from "../streaming";
 import { IcyAdapter } from "../streaming";
 import { UserModel } from '../db/models/user';
 import { retryable } from "@seamless-medley/utils";
@@ -39,6 +39,8 @@ export type MedleyServerOptions = {
 }
 
 export class MedleyServer extends SocketServerController<RemoteTypes> {
+  #instanceName: string = "Medley";
+
   #musicDb!: MusicDb;
 
   #settingsDb!: SettingsDb;
@@ -71,6 +73,9 @@ export class MedleyServer extends SocketServerController<RemoteTypes> {
     if (this.#rtcTransponder) {
       this.register('transponder', '~', new ExposedTransponder(this.#rtcTransponder));
     }
+
+    this.#instanceName = this.#configs.instanceName;
+    logger.info(`Medley server name: "${this.#instanceName}"`);
 
     this.#stations = await this.#createStations();
     this.#automatons = await this.#createAutomatons();
@@ -120,6 +125,10 @@ export class MedleyServer extends SocketServerController<RemoteTypes> {
 
   get stations() {
     return this.#stations;
+  }
+
+  get instanceName() {
+    return this.#instanceName;
   }
 
   async createAutomaton(id: string, config: AutomatonConfig) {

--- a/packages/radio/src/server/medley-server.ts
+++ b/packages/radio/src/server/medley-server.ts
@@ -23,7 +23,7 @@ import { MedleyAutomaton } from "../discord/automaton";
 import { AutomatonConfig } from "../config/automaton";
 import { StreamingConfig } from "../config/streaming";
 import { StreamingAdapter } from "../streaming/types";
-import { ShoutAdapter } from "../streaming";
+import { ShoutAdapter } from "../streaming/shout/adapter";
 import { IcyAdapter } from "../streaming";
 import { UserModel } from '../db/models/user';
 import { retryable } from "@seamless-medley/utils";
@@ -39,7 +39,7 @@ export type MedleyServerOptions = {
 }
 
 export class MedleyServer extends SocketServerController<RemoteTypes> {
-  #instanceName: string = "Medley";
+  #instanceName: string | undefined = "Medley";
 
   #musicDb!: MusicDb;
 

--- a/packages/radio/src/ui/pages/home.tsx
+++ b/packages/radio/src/ui/pages/home.tsx
@@ -13,6 +13,7 @@ const route = createRoute({
     const { surrogate: $global } = useSurrogate(StubGlobal, 'global', '$');
 
     const [stations, setStations] = useState<string[]>([]);
+    const [instanceName, setInstanceName] = useState<string>();
 
     useEffect(() => {
       if (!$global ) {
@@ -20,10 +21,13 @@ const route = createRoute({
       }
 
       $global.getStations().then(setStations);
+      $global.getInstanceName().then(setInstanceName);
     }, [$global]);
 
     return (
       <div>
+        <h2>{instanceName}</h2>
+
         <h2>Play</h2>
         <div>
           {stations.map((statioId) => (
@@ -32,7 +36,7 @@ const route = createRoute({
                 to={playRoute.id}
                 params={{ station: statioId }}
               >
-                { statioId }
+                {statioId}
               </Link>
             </div>
           ))}
@@ -46,7 +50,7 @@ const route = createRoute({
                 to={stationRoute.id}
                 params={{ station: statioId }}
               >
-                { statioId }
+                {statioId}
               </Link>
             </div>
           ))}
@@ -56,4 +60,4 @@ const route = createRoute({
   }
 });
 
-export const tree = route;
+export const tree = route.addChildren([playRoute]);

--- a/packages/radio/src/ui/pages/home.tsx
+++ b/packages/radio/src/ui/pages/home.tsx
@@ -30,13 +30,13 @@ const route = createRoute({
 
         <h2>Play</h2>
         <div>
-          {stations.map((statioId) => (
-            <div key={statioId}>
+          {stations.map((stationId) => (
+            <div key={stationId}>
               <Link
                 to={playRoute.id}
-                params={{ station: statioId }}
+                params={{ station: stationId }}
               >
-                {statioId}
+                {stationId}
               </Link>
             </div>
           ))}

--- a/packages/radio/src/ui/stubs/core/global.ts
+++ b/packages/radio/src/ui/stubs/core/global.ts
@@ -4,6 +4,7 @@ import { noop } from "lodash";
 
 class StubbingGlobal {
   getStations = noop as any;
+  getInstanceName = noop as any;
 }
 
 export const StubGlobal = StubOf<RemoteGlobal>(StubbingGlobal);


### PR DESCRIPTION
This pull request introduces a new optional configuration property `instanceName` to the Medley server and integrates it throughout the codebase. The changes include updates to the schema, server configuration, and UI to support and display the instance name.

### Configuration and Schema Updates:
* Added `instanceName` property to `medley-schema.json` and made it optional in the configuration object (`packages/radio/medley-schema.json`, `packages/radio/src/config/index.ts`). [[1]](diffhunk://#diff-a2ab4c2299e71f5bbde262259f7649a8cc27f8531e661a7aef093da9f7a6f205R7-R12) [[2]](diffhunk://#diff-c41f6d9dce200b5c2d2d51bb88c1550dccf19029a39ccf0092b6de770af7a2e6R18)

### Server Enhancements:
* Introduced `getInstanceName` method in the `Global` interface and its implementation in `ExposedGlobal` (`packages/radio/src/remotes/core/global.ts`, `packages/radio/src/server/expose/core/global.ts`). [[1]](diffhunk://#diff-e77ac746e383081f93e5b0cbf3bfc8384e983e5e91b87e7db220247fc070064fR3) [[2]](diffhunk://#diff-2680049f08f6153464720aac51dfac62ee71340fd242ce59d3cf965bcd4b25c8R19-R22)
* Added `#instanceName` property to `MedleyServer` and logged the instance name on server initialization (`packages/radio/src/server/medley-server.ts`). [[1]](diffhunk://#diff-43a5ee1f9b000377283f2525f546f8e32290c9459cc6640e0f395dba9798c7efR42-R43) [[2]](diffhunk://#diff-43a5ee1f9b000377283f2525f546f8e32290c9459cc6640e0f395dba9798c7efR77-R79) [[3]](diffhunk://#diff-43a5ee1f9b000377283f2525f546f8e32290c9459cc6640e0f395dba9798c7efR130-R133)

### UI Integration:
* Updated the home page to fetch and display the instance name (`packages/radio/src/ui/pages/home.tsx`).
* Added a stub for `getInstanceName` in the UI stubs (`packages/radio/src/ui/stubs/core/global.ts`).

### Miscellaneous:
* Simplified import statements in `medley-server.ts` (`packages/radio/src/server/medley-server.ts`).
* Adjusted the routing configuration in the home page (`packages/radio/src/ui/pages/home.tsx`).